### PR TITLE
feat: Add password change functionality to user edit form

### DIFF
--- a/public/scripts/editUserForm.js
+++ b/public/scripts/editUserForm.js
@@ -3,6 +3,7 @@ async function submitEditUser() {
     const name = document.getElementById('name').value;
     const photo = document.getElementById('photo').value;
     const role = document.getElementById('role')?.value; // Role is optional and may not exist
+    const password = document.getElementById('passwordChange')?.value;
 
     const userId = document.getElementById("userId").innerText;
 
@@ -15,6 +16,10 @@ async function submitEditUser() {
     // If role exists (admin user), add it to the payload
     if (role !== undefined) {
         payload.role = parseInt(role);
+    }
+
+    if(password !== null && password !== "") {
+        payload.password = password;
     }
 
     try {

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -1,3 +1,4 @@
+import bcrypt from 'bcrypt';
 import {
     createService,
     readService,
@@ -71,6 +72,11 @@ class UserController {
         try {
             const { uid } = req.params;
             const data = req.body;
+
+            if(data.password) {
+                data.password = await bcrypt.hash(data.password, 10);
+            }
+
             const one = await updateService(uid, data);
             return res.json({
                 statusCode: 200,

--- a/src/views/partials/form-edit-user.handlebars
+++ b/src/views/partials/form-edit-user.handlebars
@@ -12,6 +12,8 @@
                     <input type="text" class="form-control" id="photo" name="photo" value="{{default.photo}}">
                 </div>
 
+               
+
                 {{#if isAdmin}}
                 <div class="mb-3">
                     <label for="role" class="form-label">Role</label>
@@ -22,7 +24,17 @@
                     </select>
                 </div>
                 {{/if}}
+            <div class="card p-3 mb-3">   
+                 <div class="mb-3">
+                    <label for="password" class="form-label">New Password</label>
+                    <input type="password" class="form-control" id="passwordChange" name="password">
+                </div>
 
+                 <div class="mb-3">
+                    <label for="confirm-password" class="form-label">Confirm Password</label>
+                    <input type="password" class="form-control" id="confirm-password" name="confirm-password">
+                </div>
+            </div>
                 <small class="text-muted mb-2" id="userId">{{default._id}}</small>
             </form>
 


### PR DESCRIPTION
This commit adds the functionality to change the password in the user edit form. The code changes include adding the password input fields in the form-edit-user.handlebars view and updating the submitEditUser function in editUserForm.js to include the password in the payload when sending the PUT request to update the user. Additionally, the users.controller.js file has been updated to hash the password using bcrypt before updating the user data in the database.